### PR TITLE
Remove use of collections.abc.ByteString

### DIFF
--- a/src/aptsources_cleanup/util/os.py
+++ b/src/aptsources_cleanup/util/os.py
@@ -2,11 +2,9 @@
 from os import __all__
 from os import *
 
-import collections.abc
-
 
 if "fspath" not in globals():
-	def fspath(path, *, _string_types=(str, collections.abc.ByteString)):
+	def fspath(path, *, _string_types=(str, bytes, bytearray)):
 		if not isinstance(path, _string_types):
 			try:
 				path = path.__fspath__()

--- a/src/aptsources_cleanup/util/strings.py
+++ b/src/aptsources_cleanup/util/strings.py
@@ -8,14 +8,13 @@ __all__ = (
 
 import operator
 import collections
-import collections.abc
 
 if __debug__:
 	from warnings import warn
 	from .itertools import map_pairs
 
 
-StringTypes = (str, collections.UserString, collections.abc.ByteString)
+StringTypes = (str, collections.UserString, bytes, bytearray)
 
 
 def startswith_token(s, prefix, separators=None):

--- a/tools/zip.py
+++ b/tools/zip.py
@@ -16,7 +16,6 @@ import argparse
 import operator
 import itertools
 import contextlib
-import collections
 from argparse import _, ngettext as _N
 from functools import partial as fpartial
 if __debug__:
@@ -355,7 +354,7 @@ def getlines(stream, delim, chunk_size=0, *, _exitstack):
 	if delim_alt is not None:
 		return map(operator.methodcaller("rstrip", delim_alt), stream)
 
-	if isinstance(delim, collections.abc.ByteString):
+	if isinstance(delim, (bytes, bytearray)):
 		return _getlines_impl_bytes(stream, delim, chunk_size, _exitstack)
 
 	assert isinstance(delim, str)
@@ -364,7 +363,7 @@ def getlines(stream, delim, chunk_size=0, *, _exitstack):
 	except UnicodeEncodeError:
 		pass
 	else:
-		assert isinstance(delim_alt, collections.abc.ByteString)
+		assert isinstance(delim_alt, (bytes, bytearray))
 		if delim_alt:
 			stream.flush()
 			return map(


### PR DESCRIPTION
This is an ABC that never really made much sense and was deprecated in https://github.com/python/cpython/issues/91896